### PR TITLE
Localisation obj

### DIFF
--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
@@ -20,6 +20,10 @@ mesh = mesh_hierarchy[0]
 
 V = FunctionSpace(mesh, 'DG', 0)
 
+# generate localisation functions
+r_loc_func = 0
+lf = LocalisationFunctions(V, r_loc_func)
+
 # the coordinates of observation (only cell)
 coords = tuple([np.array([0.5])])
 obs = tuple([0.1])
@@ -35,7 +39,7 @@ rmse = np.zeros(len(ns))
 
 
 # define the ensemble transform update step
-def ensemble_transform_step(V, n, coords, obs, sigma):
+def ensemble_transform_step(V, n, coords, obs, sigma, lf):
 
     # generate ensemble
     ensemble = []
@@ -45,9 +49,8 @@ def ensemble_transform_step(V, n, coords, obs, sigma):
 
     # generate posterior
     r_loc = 0
-    r_loc_func = 0
     weights = weight_update(ensemble, coords, obs, sigma, r_loc)
-    X = ensemble_transform_update(ensemble, weights, r_loc_func)
+    X = ensemble_transform_update(ensemble, weights, lf)
 
     # generate mean
     M = 0
@@ -66,7 +69,7 @@ for i in range(len(ns)):
 
     for j in range(niter):
 
-        k = ensemble_transform_step(V, int(ns[i]), coords, obs, sigma)
+        k = ensemble_transform_step(V, int(ns[i]), coords, obs, sigma, lf)
 
         temp_mse[j] = np.square(k - TrueMean)
 

--- a/firedrake_da/__init__.py
+++ b/firedrake_da/__init__.py
@@ -4,6 +4,7 @@ from firedrake_da.utils import *  # noqa
 from firedrake_da.observations import *  # noqa
 from firedrake_da.emd import *  # noqa
 from firedrake_da.localisation import *  # noqa
+from firedrake_da.localisation_functions import *  # noqa
 
 from firedrake_da.kalman.cov import *  # noqa
 from firedrake_da.kalman.kalman import *  # noqa

--- a/firedrake_da/localisation_functions.py
+++ b/firedrake_da/localisation_functions.py
@@ -1,0 +1,54 @@
+""" Stores localisation functions for a function space """
+
+from __future__ import absolute_import
+
+from __future__ import division
+
+from firedrake import *
+from firedrake_da import *
+from firedrake_da.localisation import *
+
+
+class LocalisationFunctions(object):
+
+    """ Stores localisation functions for all components / basis coeffs in a given function space """
+
+    def __init__(self, function_space, r_loc_func, rate=1.0):
+
+        """
+
+            :arg function_space: :class:`FunctionSpace` to find the localisation functions of
+            :type function_space: :class:`FunctionSpace`
+
+            :arg r_loc_func: The radius of localisation for each function
+            :type r_loc_func: int
+
+        """
+
+        # number of basis coeffs
+        f = Function(function_space)
+        self.function_space = function_space
+        self.nc = len(f.dat.data)
+        self.r_loc_func = r_loc_func
+
+        # iterate over dimensions, saving localisation functions for each one
+        self._list = []
+        for i in range(self.nc):
+            self._list.append(Localisation(function_space, r_loc_func, i, rate))
+
+        super(LocalisationFunctions, self).__init__()
+
+    def __iter__(self):
+        """Iterate over the list of localisation functions """
+        for m in self._list:
+            yield m
+
+    def __len__(self):
+        """Return the size of list of localisation functions (number of basis coeffs) """
+        return len(self._list)
+
+    def __getitem__(self, idx):
+        """Return a localisation function in list
+
+        :arg idx: The :class:`Function` to return """
+        return self._list[idx]

--- a/tests/ensemble_transform/test_ensemble_transform.py
+++ b/tests/ensemble_transform/test_ensemble_transform.py
@@ -33,7 +33,8 @@ def test_ensemble_transform_mean_preserving():
     weights = weight_update(ensemble, coord, obs, sigma, r_loc)
 
     # compute ensemble transform - should be 1.0's
-    new_ensemble = ensemble_transform_update(ensemble, weights, r_loc_func)
+    lf = LocalisationFunctions(fs, r_loc_func)
+    new_ensemble = ensemble_transform_update(ensemble, weights, lf)
 
     assert np.max(new_ensemble[0].dat.data[:] - 1.0) < 1e-5
     assert np.max(new_ensemble[1].dat.data[:] - 1.0) < 1e-5

--- a/tests/ml/test_coupling.py
+++ b/tests/ml/test_coupling.py
@@ -38,9 +38,11 @@ def test_coupling_mean_preserving():
     weights_f = weight_update(ensemble_f, coord, obs, sigma, r_loc)
 
     # compute ensemble transform - should be 1.0's
+    lfc = LocalisationFunctions(fsc, r_loc_func)
+    lff = LocalisationFunctions(fsf, r_loc_func)
     new_ensemble_c, new_ensemble_f = seamless_coupling_update(ensemble_c, ensemble_f,
                                                               weights_c, weights_f,
-                                                              r_loc_func)
+                                                              lfc, lff)
 
     assert np.max(new_ensemble_c[0].dat.data[:] - 1.0) < 1e-5
     assert np.max(new_ensemble_c[1].dat.data[:] - 1.0) < 1e-5

--- a/tests/test_localisation_functions.py
+++ b/tests/test_localisation_functions.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import
+
+from __future__ import division
+
+from firedrake import *
+from firedrake_da import *
+
+
+def generate_localisation_functions(fs, r_loc_func):
+
+    L = LocalisationFunctions(fs, r_loc_func)
+    for i in range(len(L)):
+        assert np.abs(1.0 - L[i].dat.data[i]) < 1e-5
+
+
+def test_loc_func_int_dg0_r0():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'DG', 0)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_int_dg1_r0():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'DG', 1)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_int_dg0_r1():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'DG', 0)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_int_dg1_r1():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'DG', 1)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_sq_dg0_r0():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'DG', 0)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_sq_dg1_r0():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'DG', 1)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_sq_dg0_r1():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'DG', 0)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_sq_dg1_r1():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'DG', 1)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_int_cg1_r0():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'CG', 1)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_int_cg1_r1():
+    m = UnitIntervalMesh(2)
+    fs = FunctionSpace(m, 'CG', 1)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_sq_cg1_r0():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'CG', 1)
+    generate_localisation_functions(fs, 0)
+
+
+def test_loc_func_sq_cg1_r1():
+    m = UnitSquareMesh(2, 2)
+    fs = FunctionSpace(m, 'CG', 1)
+    generate_localisation_functions(fs, 1)
+
+
+def test_loc_func_length():
+    m = UnitIntervalMesh(10)
+    fs = FunctionSpace(m, 'DG', 0)
+    L = LocalisationFunctions(fs, 0)
+    assert len(L) == 10
+
+
+def test_loc_func_iterate():
+    m = UnitIntervalMesh(10)
+    fs = FunctionSpace(m, 'DG', 0)
+    L = LocalisationFunctions(fs, 1)
+    i = 0
+    for l in L:
+        if i == 0:
+            assert l.dat.data[i] == 1.0
+            assert l.dat.data[i + 1] == 0.5
+        elif i == len(L) - 1:
+            assert l.dat.data[i] == 1.0
+            assert l.dat.data[i - 1] == 0.5
+        else:
+            assert l.dat.data[i] == 1.0
+            assert l.dat.data[i + 1] == 0.5
+            assert l.dat.data[i - 1] == 0.5
+        i += 1
+
+
+if __name__ == "__main__":
+    import os
+    import pytest
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Alterations:

- We add a `LocalisationFunctions` object that allows one to make all of the component's localisation functions for a given function space, taking that out of every iteration in `ensemble_transform` and ` coupling`, right at the start of assimilation and store them.
- Tested for all `FunctionSpace`s that works with basis coefficient localisation around a single vertex (DG0, DG1, DGn, CG1) with different radius of localisation
- Changed examples to create this object first and uses that. Should speed up the examples.