### PR TITLE
ObservationEfficiency

### DIFF
--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
@@ -28,6 +28,8 @@ lf = LocalisationFunctions(V, r_loc_func)
 coords = tuple([np.array([0.5])])
 obs = tuple([0.1])
 
+observation_operator = Observations(V)
+
 # denote the true mean of the posterior
 TrueMean = 0.7
 
@@ -39,7 +41,7 @@ rmse = np.zeros(len(ns))
 
 
 # define the ensemble transform update step
-def ensemble_transform_step(V, n, coords, obs, sigma, lf):
+def ensemble_transform_step(V, n, observation_operator, coords, obs, sigma, lf):
 
     # generate ensemble
     ensemble = []
@@ -49,7 +51,7 @@ def ensemble_transform_step(V, n, coords, obs, sigma, lf):
 
     # generate posterior
     r_loc = 0
-    weights = weight_update(ensemble, coords, obs, sigma, r_loc)
+    weights = weight_update(ensemble, observation_operator, coords, obs, sigma, r_loc)
     X = ensemble_transform_update(ensemble, weights, lf)
 
     # generate mean
@@ -69,7 +71,7 @@ for i in range(len(ns)):
 
     for j in range(niter):
 
-        k = ensemble_transform_step(V, int(ns[i]), coords, obs, sigma, lf)
+        k = ensemble_transform_step(V, int(ns[i]), observation_operator, coords, obs, sigma, lf)
 
         temp_mse[j] = np.square(k - TrueMean)
 

--- a/examples/kalman/demo_kalman_update_single_dg_cell.py
+++ b/examples/kalman/demo_kalman_update_single_dg_cell.py
@@ -7,6 +7,8 @@ mesh = UnitSquareMesh(1, 1)
 V = FunctionSpace(mesh, 'DG', 1)
 fs = FunctionSpace(mesh, 'DG', 0)
 
+observation_operator = Observations(V)
+
 coords = tuple([np.array([0.5, 0.5])])
 obs = tuple([0.5])
 
@@ -20,4 +22,4 @@ for i in range(n):
     ensemble.append(f)
 
 cov = Covariance(ensemble, fs)
-X = Kalman_update(ensemble, coords, obs, sigma, fs)
+X = Kalman_update(ensemble, observation_operator, coords, obs, sigma, fs)

--- a/examples/kalman/demo_kalman_update_single_dg_cell_convergence.py
+++ b/examples/kalman/demo_kalman_update_single_dg_cell_convergence.py
@@ -16,6 +16,8 @@ mesh = UnitIntervalMesh(1)
 V = FunctionSpace(mesh, 'DG', 0)
 fs = FunctionSpace(mesh, 'DG', 0)
 
+observation_operator = Observations(V)
+
 # the coordinates of observation (only cell)
 coords = tuple([np.array([0.5])])
 obs = tuple([0.1])
@@ -31,7 +33,7 @@ rmse = np.zeros(len(ns))
 
 
 # define the kalman update step
-def kalman_step(V, fs, n, coords, obs, sigma):
+def kalman_step(V, fs, n, observation_operator, coords, obs, sigma):
 
     # generate ensemble
     ensemble = []
@@ -40,7 +42,7 @@ def kalman_step(V, fs, n, coords, obs, sigma):
         ensemble.append(f)
 
     # generate posterior
-    X = Kalman_update(ensemble, coords, obs, sigma, fs)
+    X = Kalman_update(ensemble, observation_operator, coords, obs, sigma, fs)
 
     # generate mean
     M = 0
@@ -60,7 +62,7 @@ for i in range(len(ns)):
 
     for j in range(niter):
 
-        k = kalman_step(V, fs, int(ns[i]), coords, obs, sigma)
+        k = kalman_step(V, fs, int(ns[i]), observation_operator, coords, obs, sigma)
 
         temp_mse[j] = np.square(k - TrueMean)
 

--- a/examples/ml/demo_mlmc_convergence_posterior_statistics.py
+++ b/examples/ml/demo_mlmc_convergence_posterior_statistics.py
@@ -33,10 +33,13 @@ sigma = 2.0
 # define the function space hierarchy
 fs_hierarchy = tuple([FunctionSpace(m, 'DG', 0) for m in mesh_hierarchy])
 
+# observation operator hierarchy
+oo_hierarchy = tuple([Observations(fs) for fs in fs_hierarchy])
+
 
 # define the function to calculate the multilevel monte carlo estimate of
 # posterior mean
-def mlmc_estimate(N0, fs_hierarchy, means, coords, obs, sigma):
+def mlmc_estimate(N0, fs_hierarchy, means, oo_hierarchy, coords, obs, sigma):
 
     eh = EnsembleHierarchy(fs_hierarchy)
     L = len(fs_hierarchy) - 1
@@ -58,8 +61,8 @@ def mlmc_estimate(N0, fs_hierarchy, means, coords, obs, sigma):
 
         # weight calculation
         r_loc = 0
-        weights_c = weight_update(coarse, coords, obs, sigma, r_loc)
-        weights_f = weight_update(fine, coords, obs, sigma, r_loc)
+        weights_c = weight_update(coarse, oo_hierarchy[i], coords, obs, sigma, r_loc)
+        weights_f = weight_update(fine, oo_hierarchy[i + 1], coords, obs, sigma, r_loc)
 
         # transform / couple
         new_coarse, new_fine = seamless_coupling_update(coarse,
@@ -106,7 +109,7 @@ for i in range(s):
     for j in range(niter):
 
         m_func, v_func = mlmc_estimate(N0s[i], fs_hierarchy, means,
-                                       coords, obs, sigma)
+                                       oo_hierarchy, coords, obs, sigma)
 
         temp_rmse_func[j] = np.square(m_func)
 

--- a/examples/ml/demo_seamless_coupling_update_single_dg_cell_convergence.py
+++ b/examples/ml/demo_seamless_coupling_update_single_dg_cell_convergence.py
@@ -29,6 +29,9 @@ lff = LocalisationFunctions(Vf, r_loc_func)
 coords = tuple([np.array([0.5])])
 obs = tuple([0.1])
 
+observation_operator_c = Observations(Vc)
+observation_operator_f = Observations(Vf)
+
 # denote the true mean of both the coarse and fine posterior in the single cell
 TrueMean = 0.7
 
@@ -41,7 +44,7 @@ rmse_f = np.zeros(len(ns))
 
 
 # define the seamless coupling update step
-def seamless_coupling_step(Vc, Vf, n, coords, obs, sigma, lfc, lff):
+def seamless_coupling_step(Vc, Vf, n, oo_c, oo_f, coords, obs, sigma, lfc, lff):
 
     # generate ensemble
     ensemble_c = []
@@ -54,8 +57,8 @@ def seamless_coupling_step(Vc, Vf, n, coords, obs, sigma, lfc, lff):
 
     # generate coarse and fine posterior
     r_loc = 0
-    weights_c = weight_update(ensemble_c, coords, obs, sigma, r_loc)
-    weights_f = weight_update(ensemble_f, coords, obs, sigma, r_loc)
+    weights_c = weight_update(ensemble_c, oo_c, coords, obs, sigma, r_loc)
+    weights_f = weight_update(ensemble_f, oo_f, coords, obs, sigma, r_loc)
     Xc, Xf = seamless_coupling_update(ensemble_c, ensemble_f, weights_c, weights_f, lfc, lff)
 
     # generate coarse / fine mean at the cell which contains coordinate of observation
@@ -81,7 +84,8 @@ for i in range(len(ns)):
 
     for j in range(niter):
 
-        kc, kf = seamless_coupling_step(Vc, Vf, int(ns[i]), coords, obs, sigma, lfc, lff)
+        kc, kf = seamless_coupling_step(Vc, Vf, int(ns[i]), observation_operator_c,
+                                        observation_operator_f, coords, obs, sigma, lfc, lff)
 
         temp_mse_c[j] = np.square(kc - TrueMean)
         temp_mse_f[j] = np.square(kf - TrueMean)

--- a/firedrake_da/kalman/kalman.py
+++ b/firedrake_da/kalman/kalman.py
@@ -12,12 +12,16 @@ from firedrake_da.kalman.cov import *
 from firedrake_da.observations import *
 
 
-def Kalman_update(ensemble, observation_coords, observations, sigma, fs_to_project_to="default"):
+def Kalman_update(ensemble, observation_operator, observation_coords, observations,
+                  sigma, fs_to_project_to="default"):
 
     """
 
         :arg ensemble: list of :class:`Function`s in the ensemble
         :type ensemble: tuple / list
+
+        :arg observation_operator: the :class:`Observations` for the assimilation problem
+        :type observation_operator: :class:`Observations`
 
         :arg observation_coords: tuple / list defining the coords of observations
         :type observation_coords: tuple / list
@@ -55,12 +59,12 @@ def Kalman_update(ensemble, observation_coords, observations, sigma, fs_to_proje
 
     # difference in the observation space
     p = 1
-    O = Observations(observation_coords, observations, mesh)
+    observation_operator.update_observation_operator(observation_coords, observations)
     D = []
     for i in range(n):
         f = Function(fs_to_project_to)
         # have to project that difference functions back into the fs_to_project_to
-        f.project(O.difference(ensemble[i], p))
+        f.project(observation_operator.difference(ensemble[i], p))
         D.append(f)
 
     # now put this difference in matrix of data

--- a/tests/ensemble_transform/test_ensemble_transform.py
+++ b/tests/ensemble_transform/test_ensemble_transform.py
@@ -30,7 +30,8 @@ def test_ensemble_transform_mean_preserving():
 
     # compute weights - should be even
     sigma = 0.1
-    weights = weight_update(ensemble, coord, obs, sigma, r_loc)
+    observation_operator = Observations(fs)
+    weights = weight_update(ensemble, observation_operator, coord, obs, sigma, r_loc)
 
     # compute ensemble transform - should be 1.0's
     lf = LocalisationFunctions(fs, r_loc_func)

--- a/tests/ensemble_transform/test_weight_update.py
+++ b/tests/ensemble_transform/test_weight_update.py
@@ -29,7 +29,8 @@ def test_weight_update_perfect_observation():
 
     # compute weights - should be even
     sigma = 0.1
-    weights = weight_update(ensemble, coord, obs, sigma, r_loc)
+    observation_operator = Observations(fs)
+    weights = weight_update(ensemble, observation_operator, coord, obs, sigma, r_loc)
 
     # check weights are even
     assert np.max(np.abs(weights[0].dat.data[:] - 0.5)) < 1e-5

--- a/tests/ml/test_coupling.py
+++ b/tests/ml/test_coupling.py
@@ -34,8 +34,10 @@ def test_coupling_mean_preserving():
 
     # compute weights - should be even
     sigma = 0.1
-    weights_c = weight_update(ensemble_c, coord, obs, sigma, r_loc)
-    weights_f = weight_update(ensemble_f, coord, obs, sigma, r_loc)
+    observation_operator_c = Observations(fsc)
+    observation_operator_f = Observations(fsf)
+    weights_c = weight_update(ensemble_c, observation_operator_c, coord, obs, sigma, r_loc)
+    weights_f = weight_update(ensemble_f, observation_operator_f, coord, obs, sigma, r_loc)
 
     # compute ensemble transform - should be 1.0's
     lfc = LocalisationFunctions(fsc, r_loc_func)


### PR DESCRIPTION
Alterations:

- Changed the way `Observations` is set-up. Now the initialization of the operator (at the start of assimilation) is done once, and separately from the update of the aggregated projection of observations onto observation space for each assimilation step with a new set of observations. Then also, now `difference` instance is made more efficient by the fact that projections are taken care of in the initialization (as `FunctionSpace` is provided at the start) and that one can find the aggregated observation function once for the whole ensemble.
- Members now just have the differences by subtracting themselves from this aggregated function.
- All convergence examples/demos come back consistent and tests pass (with a few more added).
- Benchmark (local machine) runtime profiles for ensemble transform and coupling show speed-up now for difference finding (as it's now linear for the number of observations - not multiplied by the ensemble size like it was before).