### PR TITLE
efficient_weight_update

### DIFF
--- a/firedrake_da/localisation.py
+++ b/firedrake_da/localisation.py
@@ -40,8 +40,8 @@ def CoarseningLocalisation(f, r_loc):
     fc = Function(FunctionSpace(hierarchy[lvl - r_loc], fs.ufl_element()))
     inject(f, fc)
 
-    # prolong back again
-    f_new = Function(fs)
-    prolong(fc, f_new)
+    # reset f and prolong back again
+    f.assign(0)
+    prolong(fc, f)
 
-    return f_new
+    return f

--- a/tests/test_localisation.py
+++ b/tests/test_localisation.py
@@ -22,10 +22,11 @@ def test_coarsening_localisation_single_cell_dg0():
     fs_hierarchy = tuple([FunctionSpace(m, 'DG', 0) for m in mesh_hierarchy])
 
     WLoc = Function(fs_hierarchy[-1]).assign(1.0)
+    WLoc_ = Function(fs_hierarchy[-1]).assign(WLoc)
 
-    WLocNew = CoarseningLocalisation(WLoc, r_loc)
+    WLoc = CoarseningLocalisation(WLoc, r_loc)
 
-    assert norm(assemble(WLoc - WLocNew)) == 0
+    assert norm(assemble(WLoc - WLoc_)) == 0
 
 
 def test_coarsening_localisation_single_cell_dg0_2():
@@ -41,10 +42,10 @@ def test_coarsening_localisation_single_cell_dg0_2():
     WLoc = Function(fs_hierarchy[1])
     WLoc.dat.data[0] = 1.0
 
-    WLocNew = CoarseningLocalisation(WLoc, r_loc)
+    WLoc = CoarseningLocalisation(WLoc, r_loc)
 
-    assert np.abs(0.5 - WLocNew.dat.data[0]) < 1e-5
-    assert np.abs(0.5 - WLocNew.dat.data[1]) < 1e-5
+    assert np.abs(0.5 - WLoc.dat.data[0]) < 1e-5
+    assert np.abs(0.5 - WLoc.dat.data[1]) < 1e-5
 
 
 def test_coarsening_localisation_no_localisation():
@@ -61,9 +62,11 @@ def test_coarsening_localisation_no_localisation():
 
     WLoc.dat.data[0] += 1.0
 
-    WLocNew = CoarseningLocalisation(WLoc, r_loc)
+    WLoc_ = Function(fs_hierarchy[-1]).assign(WLoc)
 
-    assert norm(assemble(WLoc - WLocNew)) == 0
+    WLoc = CoarseningLocalisation(WLoc, r_loc)
+
+    assert norm(assemble(WLoc - WLoc_)) == 0
 
 
 def test_coarsening_localisation_no_hierarchy():
@@ -80,13 +83,15 @@ def test_coarsening_localisation_no_hierarchy():
 
         WLoc.dat.data[0] += 1.0
 
+        WLoc_ = Function(fs).assign(WLoc)
+
         if r == 1:
             with pytest.raises(Exception):
                 CoarseningLocalisation(WLoc, r)
 
         if r == 0:
-            C = CoarseningLocalisation(WLoc, r)
-            assert C == WLoc
+            WLoc = CoarseningLocalisation(WLoc, r)
+            assert norm(assemble(WLoc - WLoc_)) == 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alterations:

- Removed pointless pre-allocation of another set of `Function`s in `weight_update.py`.

- Changed `CoarseningLocalisation` so that it now just simply returns the localised `Function` assigned to the `Function` that is input. This doesn't effect anything in `weight_update.py` and neither does it when called in the cost tensor generation in `emd_kernel.py`.

- Only tests are effected -> these are now changed.