### PR TITLE
ensemble_vector_functions_efficiency

### DIFF
--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_algorithm_runtime.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_algorithm_runtime.py
@@ -50,13 +50,16 @@ def ensemble_transform_step(V, n, observation_operator, coords, obs, sigma, lf):
 
     # generate ensemble
     ensemble = []
+    weights = []
     for i in range(n):
         f = Function(V).assign(np.random.normal(1, 1, 1)[0])
+        g = Function(V).assign(1.0 / n)
         ensemble.append(f)
+        weights.append(g)
 
     # generate posterior
     r_loc = 0
-    weights = weight_update(ensemble, observation_operator, coords, obs, sigma, r_loc)
+    weights = weight_update(ensemble, weights, observation_operator, coords, obs, sigma, r_loc)
     X = ensemble_transform_update(ensemble, weights, lf)
 
     # generate mean

--- a/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
+++ b/examples/ensemble_transform/demo_ensemble_transform_update_single_dg_cell_convergence.py
@@ -41,13 +41,16 @@ def ensemble_transform_step(V, n, observation_operator, coords, obs, sigma):
 
     # generate ensemble
     ensemble = []
+    weights = []
     for i in range(n):
         f = Function(V).assign(np.random.normal(1, 1, 1)[0])
+        g = Function(V).assign(1.0 / n)
         ensemble.append(f)
+        weights.append(g)
 
     # generate posterior
     r_loc = 0
-    weights = weight_update(ensemble, observation_operator, coords, obs, sigma, r_loc)
+    weights = weight_update(ensemble, weights, observation_operator, coords, obs, sigma, r_loc)
     X = ensemble_transform_update(ensemble, weights, r_loc)
 
     # generate mean

--- a/examples/ml/demo_mlmc_convergence_posterior_statistics.py
+++ b/examples/ml/demo_mlmc_convergence_posterior_statistics.py
@@ -50,16 +50,22 @@ def mlmc_estimate(N0, fs_hierarchy, means, oo_hierarchy, coords, obs, sigma):
         ns[i] = n
         coarse = []
         fine = []
+        weights_c = []
+        weights_f = []
         for k in range(n):
             xc = np.random.normal(0, 1, 1)[0] + means[i]
             xf = np.random.normal(0, 1, 1)[0] + means[i + 1]
             coarse.append(Function(fs_hierarchy[i]).assign(xc))
             fine.append(Function(fs_hierarchy[i + 1]).assign(xf))
+            hc = Function(fs_hierarchy[i]).assign(1.0 / n)
+            weights_c.append(hc)
+            hf = Function(fs_hierarchy[i + 1]).assign(1.0 / n)
+            weights_f.append(hf)
 
         # weight calculation
         r_loc = 0
-        weights_c = weight_update(coarse, oo_hierarchy[i], coords, obs, sigma, r_loc)
-        weights_f = weight_update(fine, oo_hierarchy[i + 1], coords, obs, sigma, r_loc)
+        weights_c = weight_update(coarse, weights_c, oo_hierarchy[i], coords, obs, sigma, r_loc)
+        weights_f = weight_update(fine, weights_f, oo_hierarchy[i + 1], coords, obs, sigma, r_loc)
 
         # transform / couple
         new_coarse, new_fine = seamless_coupling_update(coarse,

--- a/examples/ml/demo_seamless_coupling_update_single_dg_cell_convergence.py
+++ b/examples/ml/demo_seamless_coupling_update_single_dg_cell_convergence.py
@@ -44,16 +44,22 @@ def seamless_coupling_step(Vc, Vf, n, oo_c, oo_f, coords, obs, sigma):
     # generate ensemble
     ensemble_c = []
     ensemble_f = []
+    weights_c = []
+    weights_f = []
     for i in range(n):
         f = Function(Vc).assign(np.random.normal(1, 1, 1)[0])
         ensemble_c.append(f)
         g = Function(Vf).assign(np.random.normal(1, 1, 1)[0])
         ensemble_f.append(g)
+        hc = Function(Vc).assign(1.0 / n)
+        weights_c.append(hc)
+        hf = Function(Vf).assign(1.0 / n)
+        weights_f.append(hf)
 
     # generate coarse and fine posterior
     r_loc = 0
-    weights_c = weight_update(ensemble_c, oo_c, coords, obs, sigma, r_loc)
-    weights_f = weight_update(ensemble_f, oo_f, coords, obs, sigma, r_loc)
+    weights_c = weight_update(ensemble_c, weights_c, oo_c, coords, obs, sigma, r_loc)
+    weights_f = weight_update(ensemble_f, weights_f, oo_f, coords, obs, sigma, r_loc)
     Xc, Xf = seamless_coupling_update(ensemble_c, ensemble_f, weights_c, weights_f, r_loc, r_loc)
 
     # generate coarse / fine mean at the cell which contains coordinate of observation

--- a/tests/ensemble_transform/test_weight_update.py
+++ b/tests/ensemble_transform/test_weight_update.py
@@ -24,13 +24,16 @@ def test_weight_update_perfect_observation():
     # build ensemble
     fs = FunctionSpace(mesh_hierarchy[-1], 'DG', 0)
     ensemble = [Function(fs), Function(fs)]
+    weights = [Function(fs), Function(fs)]
     ensemble[0].assign(1.0)
     ensemble[1].assign(1.0)
+    weights[0].assign(0.5)
+    weights[1].assign(0.5)
 
     # compute weights - should be even
     sigma = 0.1
     observation_operator = Observations(fs)
-    weights = weight_update(ensemble, observation_operator, coord, obs, sigma, r_loc)
+    weights = weight_update(ensemble, weights, observation_operator, coord, obs, sigma, r_loc)
 
     # check weights are even
     assert np.max(np.abs(weights[0].dat.data[:] - 0.5)) < 1e-5

--- a/tests/ml/test_coupling.py
+++ b/tests/ml/test_coupling.py
@@ -67,7 +67,7 @@ def test_reset_weights():
 
     coord = tuple([np.array([0.5])])
 
-    obs = tuple([1])
+    obs = tuple([0.75])
 
     # build ensemble
     fsc = FunctionSpace(mesh_hierarchy[-2], 'DG', 0)
@@ -77,9 +77,9 @@ def test_reset_weights():
     weights_c = [Function(fsc), Function(fsc)]
     weights_f = [Function(fsf), Function(fsf)]
     ensemble_c[0].assign(1.0)
-    ensemble_c[1].assign(1.0)
+    ensemble_c[1].assign(1.5)
     ensemble_f[0].assign(1.0)
-    ensemble_f[1].assign(1.0)
+    ensemble_f[1].assign(1.5)
     weights_c[0].assign(0.5)
     weights_c[1].assign(0.5)
     weights_f[0].assign(0.5)

--- a/tests/ml/test_coupling.py
+++ b/tests/ml/test_coupling.py
@@ -27,17 +27,23 @@ def test_coupling_mean_preserving():
     fsf = FunctionSpace(mesh_hierarchy[-1], 'DG', 0)
     ensemble_c = [Function(fsc), Function(fsc)]
     ensemble_f = [Function(fsf), Function(fsf)]
+    weights_c = [Function(fsc), Function(fsc)]
+    weights_f = [Function(fsf), Function(fsf)]
     ensemble_c[0].assign(1.0)
     ensemble_c[1].assign(1.0)
     ensemble_f[0].assign(1.0)
     ensemble_f[1].assign(1.0)
+    weights_c[0].assign(0.5)
+    weights_c[1].assign(0.5)
+    weights_f[0].assign(0.5)
+    weights_f[1].assign(0.5)
 
     # compute weights - should be even
     sigma = 0.1
     observation_operator_c = Observations(fsc)
     observation_operator_f = Observations(fsf)
-    weights_c = weight_update(ensemble_c, observation_operator_c, coord, obs, sigma, r_loc)
-    weights_f = weight_update(ensemble_f, observation_operator_f, coord, obs, sigma, r_loc)
+    weights_c = weight_update(ensemble_c, weights_c, observation_operator_c, coord, obs, sigma, r_loc)
+    weights_f = weight_update(ensemble_f, weights_f, observation_operator_f, coord, obs, sigma, r_loc)
 
     # compute ensemble transform - should be 1.0's
     new_ensemble_c, new_ensemble_f = seamless_coupling_update(ensemble_c, ensemble_f,
@@ -49,6 +55,52 @@ def test_coupling_mean_preserving():
 
     assert np.max(new_ensemble_f[0].dat.data[:] - 1.0) < 1e-5
     assert np.max(new_ensemble_f[1].dat.data[:] - 1.0) < 1e-5
+
+
+def test_reset_weights():
+
+    mesh = UnitIntervalMesh(1)
+
+    mesh_hierarchy = MeshHierarchy(mesh, 3)
+    r_loc = 2
+    r_loc_cost = 0
+
+    coord = tuple([np.array([0.5])])
+
+    obs = tuple([1])
+
+    # build ensemble
+    fsc = FunctionSpace(mesh_hierarchy[-2], 'DG', 0)
+    fsf = FunctionSpace(mesh_hierarchy[-1], 'DG', 0)
+    ensemble_c = [Function(fsc), Function(fsc)]
+    ensemble_f = [Function(fsf), Function(fsf)]
+    weights_c = [Function(fsc), Function(fsc)]
+    weights_f = [Function(fsf), Function(fsf)]
+    ensemble_c[0].assign(1.0)
+    ensemble_c[1].assign(1.0)
+    ensemble_f[0].assign(1.0)
+    ensemble_f[1].assign(1.0)
+    weights_c[0].assign(0.5)
+    weights_c[1].assign(0.5)
+    weights_f[0].assign(0.5)
+    weights_f[1].assign(0.5)
+
+    # compute weights - should be even
+    sigma = 0.1
+    observation_operator_c = Observations(fsc)
+    observation_operator_f = Observations(fsf)
+    weights_c = weight_update(ensemble_c, weights_c, observation_operator_c, coord, obs, sigma, r_loc)
+    weights_f = weight_update(ensemble_f, weights_f, observation_operator_f, coord, obs, sigma, r_loc)
+
+    # compute ensemble transform - should be 1.0's
+    seamless_coupling_update(ensemble_c, ensemble_f, weights_c, weights_f, r_loc_cost,
+                             r_loc_cost)
+
+    assert np.max(np.abs(weights_c[0].dat.data[:] - 0.5)) < 1e-5
+    assert np.max(np.abs(weights_c[1].dat.data[:] - 0.5)) < 1e-5
+
+    assert np.max(np.abs(weights_f[0].dat.data[:] - 0.5)) < 1e-5
+    assert np.max(np.abs(weights_f[1].dat.data[:] - 0.5)) < 1e-5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alterations:

- **Changed the way weights are calculated, uses previous weight as functions to store the next one in - saves preallocation time.**

- **Changed weight tests to take into account of this, and demos to add an extra argument in**

- _Made all ensembles within `ensemble_transform_update.py` and `seamless_coupling_update.py` vector `Function`s and thus this saves all preallocation costs on those ensembles._

- _Tests have been changed to adapt to this change._

Benchmark tests have been coming through positive, with the new scheme matching the old one for speed at least where only one update is done, and with relatively small N. Then as N increases, or we have consecutive transforms, the preallocation costs decrease.

Requirements:

- ~~Look at how the same can be done for weights, treating them as vector `Function`s.~~
- [x] Check if the heavy cost of injecting / coarsen localising the vector functions is worth it to put into `emd_kernel.py` cost tensor calculations to remove ALL preallocation.